### PR TITLE
Add user input thumbs up and down reaction

### DIFF
--- a/workspaces/agent-forge/package-lock.json
+++ b/workspaces/agent-forge/package-lock.json
@@ -38119,7 +38119,7 @@
     },
     "plugins/agent-forge": {
       "name": "@caipe/plugin-agent-forge",
-      "version": "0.3.39",
+      "version": "0.3.40",
       "license": "Apache-2.0",
       "dependencies": {
         "@agentic-profile/a2a-client": "^0.6.2",

--- a/workspaces/agent-forge/plugins/agent-forge/config.d.ts
+++ b/workspaces/agent-forge/plugins/agent-forge/config.d.ts
@@ -76,6 +76,18 @@ export interface Config {
     useOpenIDToken?: boolean;
 
     /**
+     * Whether to enable feedback (default: false)
+     * @visibility frontend
+     */
+    enableFeedback?: boolean;
+
+    /**
+     * The endpoint for submitting feedback (default: /submit_feedback)
+     * @visibility frontend
+     */
+    feedbackEndpoint?: string;
+
+    /**
      * The header title to display (default: bot name)
      * @visibility frontend
      */

--- a/workspaces/agent-forge/plugins/agent-forge/package.json
+++ b/workspaces/agent-forge/plugins/agent-forge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@caipe/plugin-agent-forge",
-  "version": "0.3.39",
+  "version": "0.3.40",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "exports": {

--- a/workspaces/agent-forge/plugins/agent-forge/src/components/ChatContainer.tsx
+++ b/workspaces/agent-forge/plugins/agent-forge/src/components/ChatContainer.tsx
@@ -36,7 +36,7 @@ import React, {
   useState,
   memo,
 } from 'react';
-import { Message } from '../types';
+import { Message, Feedback } from '../types';
 import { ChatMessage } from './ChatMessage';
 
 const useStyles = makeStyles(theme => ({
@@ -221,6 +221,12 @@ export interface ChatContainerProps {
   onSuggestionClick: (suggestion: string) => void;
   onMetadataSubmit?: (messageId: string, data: Record<string, any>) => void;
 
+  // Feedback props
+  enableFeedback?: boolean;
+  feedback?: { [key: number]: Feedback };
+  onFeedbackChange?: (index: number, feedback: Feedback) => void;
+  onFeedbackSubmit?: (index: number, feedback: Feedback) => void;
+
   // Scroll-based message loading
   onScroll?: (
     scrollTop: number,
@@ -258,6 +264,10 @@ const MessagesList = memo(function MessagesList({
   autoExpandExecutionPlans,
   executionPlanLoading,
   onMetadataSubmit,
+  enableFeedback,
+  feedback,
+  onFeedbackChange,
+  onFeedbackSubmit,
 }: {
   messages: Message[];
   botName: string;
@@ -273,6 +283,10 @@ const MessagesList = memo(function MessagesList({
   autoExpandExecutionPlans?: Set<string>;
   executionPlanLoading?: Set<string>;
   onMetadataSubmit?: (messageId: string, data: Record<string, any>) => void;
+  enableFeedback?: boolean;
+  feedback?: { [key: number]: Feedback };
+  onFeedbackChange?: (index: number, feedback: Feedback) => void;
+  onFeedbackSubmit?: (index: number, feedback: Feedback) => void;
 }) {
   // Memoize font sizes to prevent re-creating object on every render
   const memoizedFontSizes = useMemo(
@@ -307,6 +321,18 @@ const MessagesList = memo(function MessagesList({
             autoExpandExecutionPlans={autoExpandExecutionPlans}
             executionPlanLoading={executionPlanLoading}
             onMetadataSubmit={onMetadataSubmit}
+            enableFeedback={enableFeedback}
+            messageFeedback={feedback?.[index]}
+            onFeedbackChange={
+              onFeedbackChange
+                ? newFeedback => onFeedbackChange(index, newFeedback)
+                : undefined
+            }
+            onFeedbackSubmit={
+              onFeedbackSubmit
+                ? feedbackData => onFeedbackSubmit(index, feedbackData)
+                : undefined
+            }
           />
         </div>
       ))}
@@ -342,6 +368,10 @@ export const ChatContainer = memo(function ChatContainer({
   botName,
   botIcon,
   inputPlaceholder,
+  enableFeedback = false,
+  feedback,
+  onFeedbackChange,
+  onFeedbackSubmit,
   fontSizes,
   onMessageSubmit,
   onCancelRequest,
@@ -598,9 +628,14 @@ export const ChatContainer = memo(function ChatContainer({
           botIcon={botIcon}
           fontSizes={fontSizes}
           executionPlanBuffer={executionPlanBuffer}
+          executionPlanHistory={executionPlanHistory}
           autoExpandExecutionPlans={autoExpandExecutionPlans}
           executionPlanLoading={executionPlanLoading}
           onMetadataSubmit={onMetadataSubmit}
+          enableFeedback={enableFeedback}
+          feedback={feedback}
+          onFeedbackChange={onFeedbackChange}
+          onFeedbackSubmit={onFeedbackSubmit}
         />
 
         {isTyping && (

--- a/workspaces/agent-forge/plugins/agent-forge/src/components/ChatFeedback.tsx
+++ b/workspaces/agent-forge/plugins/agent-forge/src/components/ChatFeedback.tsx
@@ -1,0 +1,266 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react';
+import { Message, Feedback as FeedbackType } from '../types';
+import { ChatMessage } from './ChatMessage';
+import { Box, Chip, Button, TextField } from '@material-ui/core';
+import { alertApiRef, useApi } from '@backstage/core-plugin-api';
+import { ChatbotApi } from '../apis';
+import { FeedbackButton, Feedback as FeedbackEnum } from './FeedbackButton';
+
+interface ChatFeedbackProps {
+  messages: Message[];
+  feedback: { [key: number]: FeedbackType };
+  setFeedback: React.Dispatch<
+    React.SetStateAction<{ [key: number]: FeedbackType }>
+  >;
+  setMessages: React.Dispatch<React.SetStateAction<Message[]>>;
+  chatbotApi: ChatbotApi;
+  botName?: string;
+  botIcon?: string;
+  fontSizes?: {
+    messageText?: string;
+    codeBlock?: string;
+    inlineCode?: string;
+    timestamp?: string;
+  };
+  executionPlanBuffer?: Record<string, string>;
+  executionPlanHistory?: Record<string, string[]>;
+  autoExpandExecutionPlans?: Set<string>;
+  executionPlanLoading?: Set<string>;
+  onMetadataSubmit?: (messageId: string, data: Record<string, any>) => void;
+}
+
+function ChatFeedback({
+  messages,
+  feedback,
+  setFeedback,
+  setMessages,
+  chatbotApi,
+  botName,
+  botIcon,
+  fontSizes,
+  executionPlanBuffer,
+  executionPlanHistory,
+  autoExpandExecutionPlans,
+  executionPlanLoading,
+  onMetadataSubmit,
+}: ChatFeedbackProps) {
+  const alertApi = useApi(alertApiRef);
+
+  function handleFeedback(index: number, type: FeedbackEnum) {
+    const feedbackType = type === FeedbackEnum.LIKE ? 'like' : 'dislike';
+    setFeedback(prevFeedback => {
+      const newFeedback = { ...prevFeedback };
+      if (!newFeedback[index]) {
+        newFeedback[index] = {};
+      }
+
+      if (newFeedback[index].type === feedbackType) {
+        newFeedback[index].type = undefined;
+        newFeedback[index].showFeedbackOptions = false;
+      } else {
+        newFeedback[index].type = feedbackType;
+        newFeedback[index].showFeedbackOptions = true;
+      }
+
+      return newFeedback;
+    });
+  }
+
+  function handleFeedbackReason(index: number, reason: string) {
+    setFeedback(prevFeedback => {
+      const newFeedback = { ...prevFeedback };
+      if (!newFeedback[index]) {
+        newFeedback[index] = {};
+      }
+      newFeedback[index].reason = reason;
+      newFeedback[index].promptForFeedback = reason === 'Other';
+      return newFeedback;
+    });
+  }
+
+  async function handleSubmitFeedback(index: number) {
+    const feedbackData = feedback[index];
+    if (!feedbackData) {
+      return;
+    }
+
+    try {
+      await chatbotApi.submitFeedback(messages[index], feedbackData);
+      alertApi.post({
+        severity: 'success',
+        message: 'Thank you for your feedback!',
+      });
+      setFeedback(prevFeedback => {
+        const newFeedback = { ...prevFeedback };
+        newFeedback[index].submitted = true;
+        newFeedback[index].showFeedbackOptions = false;
+        return newFeedback;
+      });
+      const updatedMessages = messages.map((msg, i) => {
+        if (i === index) {
+          return { ...msg, showFeedbackOptions: false };
+        }
+        return msg;
+      });
+      setMessages(updatedMessages);
+    } catch (error) {
+      alertApi.post({
+        severity: 'error',
+        message:
+          'There was an error submitting your feedback. Please try again.',
+      });
+    }
+  }
+
+  function handleCopyToClipboard(index: number) {
+    const messageText = messages[index]?.text || '';
+    window.navigator.clipboard
+      .writeText(messageText)
+      .then(() => {
+        alertApi.post({
+          severity: 'success',
+          message: 'Text copied to clipboard',
+        });
+      })
+      .catch(() => {
+        alertApi.post({
+          severity: 'error',
+          message: 'Failed to copy text',
+        });
+      });
+  }
+
+  return (
+    <>
+      {messages.map((message, index) => {
+        const isLiked = feedback[index]?.type === 'like';
+        const showFeedbackOptions = feedback[index]?.showFeedbackOptions;
+        const feedbackSubmitted = feedback[index]?.submitted;
+
+        return (
+          <div
+            key={`${index}-${message.timestamp}`}
+            data-message-timestamp={message.timestamp}
+          >
+            <ChatMessage
+              message={message}
+              botName={botName}
+              botIcon={botIcon}
+              fontSizes={fontSizes}
+              executionPlanBuffer={executionPlanBuffer}
+              executionPlanHistory={executionPlanHistory}
+              autoExpandExecutionPlans={autoExpandExecutionPlans}
+              executionPlanLoading={executionPlanLoading}
+              onMetadataSubmit={onMetadataSubmit}
+            />
+
+            {!message.isUser && (
+              <Box display="flex" alignItems="center" mt={1} mb={2}>
+                <FeedbackButton
+                  enabled={!feedbackSubmitted}
+                  feedback={feedback[index]?.type}
+                  handleFeedback={fb => handleFeedback(index, fb)}
+                  handleCopyToClipBoard={() => handleCopyToClipboard(index)}
+                />
+              </Box>
+            )}
+
+            {showFeedbackOptions && !message.isUser && (
+              <Box mb={2} p={2} bgcolor="background.paper" borderRadius={1}>
+                <Box display="flex" flexWrap="wrap" mb={2}>
+                  {isLiked
+                    ? [
+                        'Very Helpful',
+                        'Accurate',
+                        'Simplified My Task',
+                        'Other',
+                      ].map(reason => (
+                        <Chip
+                          key={reason}
+                          label={reason}
+                          clickable
+                          color={
+                            feedback[index]?.reason === reason
+                              ? 'primary'
+                              : 'default'
+                          }
+                          onClick={() => handleFeedbackReason(index, reason)}
+                          style={{ margin: 4 }}
+                        />
+                      ))
+                    : [
+                        'Inaccurate',
+                        'Poorly Formatted',
+                        'Incomplete',
+                        'Off-topic',
+                        'Other',
+                      ].map(reason => (
+                        <Chip
+                          key={reason}
+                          label={reason}
+                          clickable
+                          color={
+                            feedback[index]?.reason === reason
+                              ? 'primary'
+                              : 'default'
+                          }
+                          onClick={() => handleFeedbackReason(index, reason)}
+                          style={{ margin: 4 }}
+                        />
+                      ))}
+                </Box>
+                {feedback[index]?.promptForFeedback && (
+                  <TextField
+                    fullWidth
+                    multiline
+                    rows={3}
+                    variant="outlined"
+                    placeholder="Provide additional feedback"
+                    value={feedback[index]?.additionalFeedback || ''}
+                    onChange={e =>
+                      setFeedback(prevFeedback => {
+                        const newFeedback = { ...prevFeedback };
+                        if (!newFeedback[index]) {
+                          newFeedback[index] = {};
+                        }
+                        newFeedback[index].additionalFeedback = e.target.value;
+                        return newFeedback;
+                      })
+                    }
+                    style={{ marginBottom: 8 }}
+                  />
+                )}
+                <Button
+                  variant="contained"
+                  color="primary"
+                  size="small"
+                  onClick={() => handleSubmitFeedback(index)}
+                  disabled={!feedback[index]?.reason}
+                >
+                  Submit Feedback
+                </Button>
+              </Box>
+            )}
+          </div>
+        );
+      })}
+    </>
+  );
+}
+
+export default ChatFeedback;

--- a/workspaces/agent-forge/plugins/agent-forge/src/components/FeedbackButton.tsx
+++ b/workspaces/agent-forge/plugins/agent-forge/src/components/FeedbackButton.tsx
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
+/* eslint-disable jsx-a11y/no-noninteractive-element-to-interactive-role */
+import ThumbUpIcon from '../icons/thumb-up-icon.png';
+import ThumbUpFilledIcon from '../icons/thumb-up-filled-icon.png';
+import ThumbDownIcon from '../icons/thumb-down-icon.png';
+import ThumbDownFilledIcon from '../icons/thumb-down-filled-icon.png';
+import CopyIcon from '../icons/copy.svg';
+import React from 'react';
+
+export enum Feedback {
+  LIKE = 'like',
+  DISLIKE = 'dislike',
+}
+
+export interface FeedbackButtonProps {
+  enabled: boolean;
+  feedback?: string | Feedback;
+  handleFeedback: (feedback: Feedback) => void;
+  handleCopyToClipBoard: () => void;
+}
+
+const iconStyle = {
+  width: '18px',
+  height: '18px',
+  cursor: 'pointer',
+  marginRight: '8px',
+};
+
+export function FeedbackButton({
+  enabled,
+  feedback,
+  handleFeedback,
+  handleCopyToClipBoard,
+}: FeedbackButtonProps) {
+  const handleKeyDown = (e: React.KeyboardEvent, action: () => void) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      action();
+    }
+  };
+
+  return (
+    <>
+      <img
+        style={{
+          ...iconStyle,
+          opacity: enabled ? 1 : 0.5,
+          cursor: enabled ? 'pointer' : 'not-allowed',
+        }}
+        src={feedback === Feedback.LIKE ? ThumbUpFilledIcon : ThumbUpIcon}
+        alt="Thumb up"
+        title="Thumb up"
+        onClick={() => enabled && handleFeedback(Feedback.LIKE)}
+        onKeyDown={e =>
+          handleKeyDown(e, () => enabled && handleFeedback(Feedback.LIKE))
+        }
+        role="button"
+        tabIndex={0}
+      />
+      <img
+        style={{
+          ...iconStyle,
+          opacity: enabled ? 1 : 0.5,
+          cursor: enabled ? 'pointer' : 'not-allowed',
+        }}
+        src={
+          feedback === Feedback.DISLIKE ? ThumbDownFilledIcon : ThumbDownIcon
+        }
+        alt="Thumb down"
+        title="Thumb down"
+        onClick={() => enabled && handleFeedback(Feedback.DISLIKE)}
+        onKeyDown={e =>
+          handleKeyDown(e, () => enabled && handleFeedback(Feedback.DISLIKE))
+        }
+        role="button"
+        tabIndex={0}
+      />
+      <img
+        src={CopyIcon}
+        alt="Copy to clipboard"
+        title="Copy to clipboard"
+        onClick={handleCopyToClipBoard}
+        onKeyDown={e => handleKeyDown(e, handleCopyToClipBoard)}
+        style={iconStyle}
+        role="button"
+        tabIndex={0}
+      />
+    </>
+  );
+}

--- a/workspaces/agent-forge/plugins/agent-forge/src/types.ts
+++ b/workspaces/agent-forge/plugins/agent-forge/src/types.ts
@@ -78,3 +78,12 @@ export interface Message {
   executionPlan?: string; // Execution plan for this message (persisted to history)
   executionPlanHistory?: string[]; // History of execution plan updates
 }
+
+export interface Feedback {
+  type?: string;
+  reason?: string;
+  additionalFeedback?: string;
+  showFeedbackOptions?: boolean;
+  promptForFeedback?: boolean;
+  submitted?: boolean;
+}

--- a/workspaces/agent-forge/yarn.lock
+++ b/workspaces/agent-forge/yarn.lock
@@ -1303,7 +1303,7 @@
   integrity sha512-5L/uBxmjaCIX5h8Z+uu+kA9BQLkc/Wl06UGR5ajNRxu+/XjonB5i8JpgFMrPj3LXTCPA0pv8yxUvbUi+QthGGA==
 
 "@caipe/plugin-agent-forge@file:/home/suwhang/Outshift/cnoe-io/community-plugins/workspaces/agent-forge/plugins/agent-forge":
-  version "0.3.39"
+  version "0.3.40"
   resolved "file:plugins/agent-forge"
   dependencies:
     "@agentic-profile/a2a-client" "^0.6.2"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

User can react to message with thumbs up or down. Enable by e.g. adding
```
  enableFeedback: true
  feedbackEndpoint: https://jarvis.dev.outshift.io/submit_feedback # this doesn't work for local development as Jarvis uses backstage deployemnt origin for token validation. You'll get 401 error
```
to app-config.yaml.

By default it's disabled and won't show the thumbs.

It uses backstage token to send to feedback. However in future, maybe this should be configurable to choose between id token and backstage token.

<img width="796" height="1069" alt="Screenshot 2025-11-07 at 17 17 11" src="https://github.com/user-attachments/assets/2e08c6b1-0c66-4e9e-919b-54c165565a7c" />

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
