### PR TITLE
feat: add option to pass user email and display caipe version

### DIFF
--- a/workspaces/agent-forge/package-lock.json
+++ b/workspaces/agent-forge/package-lock.json
@@ -38119,7 +38119,7 @@
     },
     "plugins/agent-forge": {
       "name": "@caipe/plugin-agent-forge",
-      "version": "0.3.41",
+      "version": "0.3.42",
       "license": "Apache-2.0",
       "dependencies": {
         "@agentic-profile/a2a-client": "^0.6.2",

--- a/workspaces/agent-forge/plugins/agent-forge/config.d.ts
+++ b/workspaces/agent-forge/plugins/agent-forge/config.d.ts
@@ -76,6 +76,13 @@ export interface Config {
     useOpenIDToken?: boolean;
 
     /**
+     * The mode to use for the user email (default: 'metadata')
+     * Options: 'none' (don't include), 'message' (prepend to text), 'metadata' (add as metadata)
+     * @visibility frontend
+     */
+    userEmailMode?: 'none' | 'message' | 'metadata';
+
+    /**
      * Automatically reload the page when OpenID token expires (default: true)
      * Only applies when useOpenIDToken is true
      * @visibility frontend

--- a/workspaces/agent-forge/plugins/agent-forge/package.json
+++ b/workspaces/agent-forge/plugins/agent-forge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@caipe/plugin-agent-forge",
-  "version": "0.3.41",
+  "version": "0.3.42",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "exports": {

--- a/workspaces/agent-forge/plugins/agent-forge/src/components/AgentForgePage.tsx
+++ b/workspaces/agent-forge/plugins/agent-forge/src/components/AgentForgePage.tsx
@@ -57,7 +57,12 @@ import {
   DEFAULT_SUGGESTIONS,
   DEFAULT_THINKING_MESSAGES,
 } from '../constants';
-import { Message, Feedback, PlatformEngineerResponse } from '../types';
+import {
+  Message,
+  Feedback,
+  PlatformEngineerResponse,
+  UserEmailMode,
+} from '../types';
 import { ChatSession, ChatStorage } from '../types/chat';
 import { createTimestamp } from '../utils';
 import { ChatContainer } from './ChatContainer';
@@ -296,6 +301,9 @@ export function AgentForgePage() {
   const authApiId = config.getOptionalString('agentForge.authApiId'); // Optional - only needed if using a custom auth provider
   const useOpenIDToken =
     config.getOptionalBoolean('agentForge.useOpenIDToken') ?? false;
+  const userEmailMode =
+    (config.getOptionalString('agentForge.userEmailMode') as UserEmailMode) ||
+    'none';
   const autoReloadOnTokenExpiry =
     config.getOptionalBoolean('agentForge.autoReloadOnTokenExpiry') ?? true;
   const enableFeedback =
@@ -351,9 +359,8 @@ export function AgentForgePage() {
       })
     : null;
   // Always call useApi to satisfy React Hooks rules, but handle null case
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   const openIdConnectApi = OpenIdConnectApiRef
-    ? useApi(OpenIdConnectApiRef)
+    ? useApi(OpenIdConnectApiRef) // eslint-disable-line react-hooks/rules-of-hooks
     : null;
 
   // Create initial session factory
@@ -415,6 +422,7 @@ export function AgentForgePage() {
     'checking' | 'connected' | 'disconnected'
   >('checking');
   const [nextRetryCountdown, setNextRetryCountdown] = useState<number>(0);
+  const [caipeVersion, setCaipeVersion] = useState<string | null>(null);
   const [loadedMessageCount, setLoadedMessageCount] = useState(
     DEFAULT_MESSAGE_COUNT,
   ); // Progressive loading count
@@ -909,7 +917,7 @@ export function AgentForgePage() {
         ' with authApiId:',
         authApiId,
       );
-
+      console.log('🔧 User email mode:', userEmailMode);
       console.log('🔧 Feedback endpoint:', feedbackEndpoint);
       console.log('🔧 Feedback enabled:', enableFeedback);
 
@@ -920,6 +928,7 @@ export function AgentForgePage() {
           {
             requestTimeout,
             useOpenIDToken,
+            userEmailMode,
             autoReloadOnTokenExpiry,
             feedbackEndpoint,
           },
@@ -1072,6 +1081,12 @@ export function AgentForgePage() {
         if (!agentCard || typeof agentCard !== 'object') {
           console.log('🔴 Agent health check failed - Invalid JSON response');
           return false;
+        }
+
+        // Extract and store the CAIPE version if available
+        if (agentCard.version) {
+          setCaipeVersion(agentCard.version);
+          console.log('🔍 CAIPE version detected:', agentCard.version);
         }
 
         console.log('🟢 Agent health check succeeded - Agent card received');
@@ -3782,6 +3797,21 @@ export function AgentForgePage() {
                 </Typography>
               </Box>
             </Tooltip>
+            {caipeVersion && (
+              <Tooltip
+                title={`CAIPE Platform Version: ${caipeVersion}`}
+                placement="bottom"
+              >
+                <Box className={classes.customHeaderStatus}>
+                  <Typography className={classes.customHeaderLabel}>
+                    CAIPE Version
+                  </Typography>
+                  <Typography className={classes.customHeaderValue}>
+                    v{caipeVersion}
+                  </Typography>
+                </Box>
+              </Tooltip>
+            )}
             <Tooltip
               title="View on NPM: @caipe/plugin-agent-forge"
               placement="bottom"
@@ -3896,6 +3926,21 @@ export function AgentForgePage() {
               </Typography>
             </Box>
           </Tooltip>
+          {caipeVersion && (
+            <Tooltip
+              title={`CAIPE Platform Version: ${caipeVersion}`}
+              placement="bottom"
+            >
+              <Box className={classes.customHeaderStatus}>
+                <Typography className={classes.customHeaderLabel}>
+                  CAIPE Version
+                </Typography>
+                <Typography className={classes.customHeaderValue}>
+                  v{caipeVersion}
+                </Typography>
+              </Box>
+            </Tooltip>
+          )}
           <Tooltip
             title="View on NPM: @caipe/plugin-agent-forge"
             placement="bottom"

--- a/workspaces/agent-forge/plugins/agent-forge/src/types.ts
+++ b/workspaces/agent-forge/plugins/agent-forge/src/types.ts
@@ -15,6 +15,12 @@
  */
 
 /**
+ * User email mode configuration
+ * @public
+ */
+export type UserEmailMode = 'none' | 'message' | 'metadata';
+
+/**
  * Platform Engineer Response Schema (A2A DataPart)
  * Single source of truth for structured responses from AI Platform Engineer.
  * Now uses Jarvis-compatible field names for consistency.

--- a/workspaces/agent-forge/yarn.lock
+++ b/workspaces/agent-forge/yarn.lock
@@ -1303,7 +1303,7 @@
   integrity sha512-5L/uBxmjaCIX5h8Z+uu+kA9BQLkc/Wl06UGR5ajNRxu+/XjonB5i8JpgFMrPj3LXTCPA0pv8yxUvbUi+QthGGA==
 
 "@caipe/plugin-agent-forge@file:/home/suwhang/Outshift/cnoe-io/community-plugins/workspaces/agent-forge/plugins/agent-forge":
-  version "0.3.41"
+  version "0.3.42"
   resolved "file:plugins/agent-forge"
   dependencies:
     "@agentic-profile/a2a-client" "^0.6.2"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

1. Add new agentForge option to make agent append user email using a new variable:
```
# app-config.yaml
agentForge:
    userEmailMode: "message" # Options: 'none' (don't include), 'message' (prepend to text), 'metadata' (add as metadata)
```
three options:
    1. "none" (default) - no user email. old method
    2. "message" - appends "The user email is XXX" as the prefix of every user message
    3. "metadata" - adds a new metadata field in the message json parts
   
<img width="769" height="230" alt="Screenshot 2025-11-10 at 21 18 40" src="https://github.com/user-attachments/assets/ca59ebbc-dedb-4bc3-9a85-751271606bf0" />

2. Add a new "CAIPE VERSION" display on the UI

<img width="1080" height="634" alt="Screenshot 2025-11-10 at 21 18 20" src="https://github.com/user-attachments/assets/edd10105-7078-4d63-84c2-9d10b82755d3" />

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
