### PR TITLE
feat: add custom agent call support and better ui

### DIFF
--- a/workspaces/agent-forge/package-lock.json
+++ b/workspaces/agent-forge/package-lock.json
@@ -38119,7 +38119,7 @@
     },
     "plugins/agent-forge": {
       "name": "@caipe/plugin-agent-forge",
-      "version": "0.3.42",
+      "version": "0.3.43",
       "license": "Apache-2.0",
       "dependencies": {
         "@agentic-profile/a2a-client": "^0.6.2",

--- a/workspaces/agent-forge/package-lock.json
+++ b/workspaces/agent-forge/package-lock.json
@@ -38119,7 +38119,7 @@
     },
     "plugins/agent-forge": {
       "name": "@caipe/plugin-agent-forge",
-      "version": "0.3.43",
+      "version": "0.3.44",
       "license": "Apache-2.0",
       "dependencies": {
         "@agentic-profile/a2a-client": "^0.6.2",

--- a/workspaces/agent-forge/plugins/agent-forge/config.d.ts
+++ b/workspaces/agent-forge/plugins/agent-forge/config.d.ts
@@ -120,6 +120,27 @@ export interface Config {
     inputPlaceholder?: string;
 
     /**
+     * Custom call buttons configuration - key is button label, value is either:
+     * - A string: the prefix text to prepend to messages
+     * - An object with 'prompt' (required) and optional 'suggestions' array
+     *
+     * Example in app-config.yaml:
+     *   customCall:
+     *     "Agent A": "Ask Agent A to do the Following:"
+     *     "Jarvis":
+     *       prompt: "Ask Jarvis agent to do the Following:"
+     *       suggestions:
+     *         - Get LLM keys
+     *         - Deploy to Production
+     *
+     * Suggestions defined under customCall will be merged with initialSuggestions
+     * and automatically trigger that custom call when clicked.
+     * @visibility frontend
+     * @deepVisibility frontend
+     */
+    customCall?: {};
+
+    /**
      * Font size configuration for various UI elements
      * @visibility frontend
      */

--- a/workspaces/agent-forge/plugins/agent-forge/package.json
+++ b/workspaces/agent-forge/plugins/agent-forge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@caipe/plugin-agent-forge",
-  "version": "0.3.42",
+  "version": "0.3.43",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "exports": {

--- a/workspaces/agent-forge/plugins/agent-forge/package.json
+++ b/workspaces/agent-forge/plugins/agent-forge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@caipe/plugin-agent-forge",
-  "version": "0.3.43",
+  "version": "0.3.44",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "exports": {

--- a/workspaces/agent-forge/plugins/agent-forge/src/components/ChatMessage.tsx
+++ b/workspaces/agent-forge/plugins/agent-forge/src/components/ChatMessage.tsx
@@ -757,6 +757,20 @@ export const ChatMessage = memo(function ChatMessage({
           >
             You
           </Typography>
+          {message.customCallLabel && (
+            <Box
+              style={{
+                backgroundColor: 'rgba(255, 255, 255, 0.25)',
+                color: '#ffffff',
+                padding: '2px 8px',
+                borderRadius: '12px',
+                fontSize: '0.7rem',
+                fontWeight: 600,
+              }}
+            >
+              {message.customCallLabel}
+            </Box>
+          )}
         </Box>
         <Box
           style={{

--- a/workspaces/agent-forge/plugins/agent-forge/src/types.ts
+++ b/workspaces/agent-forge/plugins/agent-forge/src/types.ts
@@ -64,6 +64,7 @@ export interface Message {
   streamedOutput?: string; // Complete streaming history for collapsed container
   hasFinalResult?: boolean; // Whether partial_result was received
   skipCleaning?: boolean; // Skip markdown cleaning for final results
+  customCallLabel?: string; // Label of custom call button used when sending this message
   executionPlan?: string; // Execution plan for this message (persisted to history)
   executionPlanHistory?: string[]; // History of execution plan updates
 }

--- a/workspaces/agent-forge/yarn.lock
+++ b/workspaces/agent-forge/yarn.lock
@@ -1303,7 +1303,7 @@
   integrity sha512-5L/uBxmjaCIX5h8Z+uu+kA9BQLkc/Wl06UGR5ajNRxu+/XjonB5i8JpgFMrPj3LXTCPA0pv8yxUvbUi+QthGGA==
 
 "@caipe/plugin-agent-forge@file:/home/suwhang/Outshift/cnoe-io/community-plugins/workspaces/agent-forge/plugins/agent-forge":
-  version "0.3.42"
+  version "0.3.43"
   resolved "file:plugins/agent-forge"
   dependencies:
     "@agentic-profile/a2a-client" "^0.6.2"

--- a/workspaces/agent-forge/yarn.lock
+++ b/workspaces/agent-forge/yarn.lock
@@ -1303,7 +1303,7 @@
   integrity sha512-5L/uBxmjaCIX5h8Z+uu+kA9BQLkc/Wl06UGR5ajNRxu+/XjonB5i8JpgFMrPj3LXTCPA0pv8yxUvbUi+QthGGA==
 
 "@caipe/plugin-agent-forge@file:/home/suwhang/Outshift/cnoe-io/community-plugins/workspaces/agent-forge/plugins/agent-forge":
-  version "0.3.43"
+  version "0.3.44"
   resolved "file:plugins/agent-forge"
   dependencies:
     "@agentic-profile/a2a-client" "^0.6.2"


### PR DESCRIPTION
## Add a new custom agent call support

Enable by adding this to app-config.yaml e.g.
```yaml
agentForge:
  customCall:
    "Jarvis":
      prompt: "Ask Jarvis agent to do the Following:"
      suggestions:
        - Get LLM keys
        - Deploy ArgoCD Application
    "RAG":
      prompt: "Ask RAG agent to do the Following:"
```

If the customCall has any suggestions, these suggestions will appear with other `initialSuggestions` but default to add the customCall prefix when user selects it.

<img width="2056" height="1248" alt="Screenshot 2025-11-13 at 19 13 44" src="https://github.com/user-attachments/assets/c63fa973-c15f-4062-9068-61e2eecf9680" />

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
