### PR TITLE
fix: user input field to actually use required if provided (default t…

### DIFF
--- a/workspaces/agent-forge/package-lock.json
+++ b/workspaces/agent-forge/package-lock.json
@@ -38119,7 +38119,7 @@
     },
     "plugins/agent-forge": {
       "name": "@caipe/plugin-agent-forge",
-      "version": "0.3.44",
+      "version": "0.3.45",
       "license": "Apache-2.0",
       "dependencies": {
         "@agentic-profile/a2a-client": "^0.6.2",

--- a/workspaces/agent-forge/plugins/agent-forge/package.json
+++ b/workspaces/agent-forge/plugins/agent-forge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@caipe/plugin-agent-forge",
-  "version": "0.3.44",
+  "version": "0.3.45",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "exports": {

--- a/workspaces/agent-forge/plugins/agent-forge/src/components/ChatMessage.tsx
+++ b/workspaces/agent-forge/plugins/agent-forge/src/components/ChatMessage.tsx
@@ -1953,7 +1953,7 @@ export const ChatMessage = memo(function ChatMessage({
                       field.field_values && field.field_values.length > 0
                         ? 'select'
                         : 'text',
-                    required: true,
+                    required: (field as any).required ?? true,
                     description: field.field_description,
                     placeholder: field.field_description,
                     defaultValue: field.field_values?.[0],

--- a/workspaces/agent-forge/yarn.lock
+++ b/workspaces/agent-forge/yarn.lock
@@ -1303,7 +1303,7 @@
   integrity sha512-5L/uBxmjaCIX5h8Z+uu+kA9BQLkc/Wl06UGR5ajNRxu+/XjonB5i8JpgFMrPj3LXTCPA0pv8yxUvbUi+QthGGA==
 
 "@caipe/plugin-agent-forge@file:/home/suwhang/Outshift/cnoe-io/community-plugins/workspaces/agent-forge/plugins/agent-forge":
-  version "0.3.44"
+  version "0.3.45"
   resolved "file:plugins/agent-forge"
   dependencies:
     "@agentic-profile/a2a-client" "^0.6.2"


### PR DESCRIPTION
Currently, hardcoded to always treat all fields as required. However, if provided by the agent, the provided required flag should be used

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
