### PR TITLE
fix: Remove chat area padding, fixed some color contrast

### DIFF
--- a/workspaces/agent-forge/plugins/agent-forge/src/components/AgentForgePage.tsx
+++ b/workspaces/agent-forge/plugins/agent-forge/src/components/AgentForgePage.tsx
@@ -3759,101 +3759,94 @@ export function AgentForgePage() {
           </Card>
         )}
 
-        <Card className={classes.chatCard}>
-          <CardContent className={classes.chatCardContent}>
-            <PageHeader botName={botName} botIcon={botIcon} />
+        <div className={classes.chatCard}>
+          {currentSession ? (
+            (() => {
+              // Debug logging for props passed to ChatContainer
+              console.log('🎯 CHATCONTAINER PROPS DEBUG:', {
+                messagesCount: renderedMessages.length,
+                messageTimestamps: renderedMessages.map(m => m.timestamp),
+                executionPlanBufferKeys: Object.keys(executionPlanBuffer),
+                executionPlanBufferSize:
+                  Object.keys(executionPlanBuffer).length,
+                sessionId: currentSessionId,
+              });
 
-            {currentSession ? (
-              (() => {
-                // Debug logging for props passed to ChatContainer
-                console.log('🎯 CHATCONTAINER PROPS DEBUG:', {
-                  messagesCount: renderedMessages.length,
-                  messageTimestamps: renderedMessages.map(m => m.timestamp),
-                  executionPlanBufferKeys: Object.keys(executionPlanBuffer),
-                  executionPlanBufferSize:
-                    Object.keys(executionPlanBuffer).length,
-                  sessionId: currentSessionId,
-                });
-
-                const isCurrentSessionTyping =
-                  isTypingBySession.get(currentSessionId) || false;
-                if (process.env.NODE_ENV === 'development') {
-                  console.log(
-                    '🎬 RENDERING CHATCONTAINER - isTyping:',
-                    isCurrentSessionTyping,
-                    'for session:',
-                    currentSessionId,
-                  );
-                }
-
-                return (
-                  <ChatContainer
-                    key="chat-container"
-                    messages={renderedMessages}
-                    userInput={userInput}
-                    setUserInput={setUserInput}
-                    onMessageSubmit={handleMessageSubmit}
-                    onCancelRequest={() =>
-                      handleCancelRequest(currentSessionId)
-                    }
-                    onSuggestionClick={handleSuggestionClick}
-                    onReset={resetChat}
-                    isTyping={isCurrentSessionTyping}
-                    suggestions={suggestions}
-                    onScroll={handleScroll}
-                    onLoadMore={handleLoadMore}
-                    hasMoreMessages={
-                      loadedMessageCount <
-                      (currentSession?.messages?.length || 0)
-                    }
-                    showLoadMoreButton={showLoadMoreButton}
-                    loadMoreIncrement={LOAD_MORE_INCREMENT}
-                    executionPlanBuffer={executionPlanBuffer}
-                    executionPlanHistory={executionPlanHistory}
-                    autoExpandExecutionPlans={autoExpandExecutionPlans}
-                    executionPlanLoading={executionPlanLoading}
-                    autoScrollEnabled={autoScrollEnabled}
-                    setAutoScrollEnabled={setAutoScrollEnabled}
-                    thinkingMessages={thinkingMessages}
-                    thinkingMessagesInterval={thinkingMessagesInterval}
-                    botName={botName}
-                    botIcon={botIcon}
-                    inputPlaceholder={inputPlaceholder}
-                    currentOperation={currentOperation}
-                    isInOperationalMode={isInOperationalMode}
-                    onMetadataSubmit={handleMetadataSubmit}
-                    enableFeedback={enableFeedback}
-                    feedback={feedback}
-                    onFeedbackChange={handleFeedbackChange}
-                    onFeedbackSubmit={handleFeedbackSubmit}
-                    customCallConfig={customCallConfig}
-                    selectedCustomCall={selectedCustomCall}
-                    onCustomCallClick={handleCustomCallClick}
-                    fontSizes={{
-                      messageText: fontSizes.messageText,
-                      codeBlock: fontSizes.codeBlock,
-                      inlineCode: fontSizes.inlineCode,
-                      suggestionChip: fontSizes.suggestionChip,
-                      inputField: fontSizes.inputField,
-                      timestamp: fontSizes.timestamp,
-                    }}
-                  />
+              const isCurrentSessionTyping =
+                isTypingBySession.get(currentSessionId) || false;
+              if (process.env.NODE_ENV === 'development') {
+                console.log(
+                  '🎬 RENDERING CHATCONTAINER - isTyping:',
+                  isCurrentSessionTyping,
+                  'for session:',
+                  currentSessionId,
                 );
-              })()
-            ) : (
-              <Box
-                display="flex"
-                justifyContent="center"
-                alignItems="center"
-                minHeight="200px"
-              >
-                <Typography color="textSecondary">
-                  Loading chat session...
-                </Typography>
-              </Box>
-            )}
-          </CardContent>
-        </Card>
+              }
+
+              return (
+                <ChatContainer
+                  key="chat-container"
+                  messages={renderedMessages}
+                  userInput={userInput}
+                  setUserInput={setUserInput}
+                  onMessageSubmit={handleMessageSubmit}
+                  onCancelRequest={() => handleCancelRequest(currentSessionId)}
+                  onSuggestionClick={handleSuggestionClick}
+                  onReset={resetChat}
+                  isTyping={isCurrentSessionTyping}
+                  suggestions={suggestions}
+                  onScroll={handleScroll}
+                  onLoadMore={handleLoadMore}
+                  hasMoreMessages={
+                    loadedMessageCount < (currentSession?.messages?.length || 0)
+                  }
+                  showLoadMoreButton={showLoadMoreButton}
+                  loadMoreIncrement={LOAD_MORE_INCREMENT}
+                  executionPlanBuffer={executionPlanBuffer}
+                  executionPlanHistory={executionPlanHistory}
+                  autoExpandExecutionPlans={autoExpandExecutionPlans}
+                  executionPlanLoading={executionPlanLoading}
+                  autoScrollEnabled={autoScrollEnabled}
+                  setAutoScrollEnabled={setAutoScrollEnabled}
+                  thinkingMessages={thinkingMessages}
+                  thinkingMessagesInterval={thinkingMessagesInterval}
+                  botName={botName}
+                  botIcon={botIcon}
+                  inputPlaceholder={inputPlaceholder}
+                  currentOperation={currentOperation}
+                  isInOperationalMode={isInOperationalMode}
+                  onMetadataSubmit={handleMetadataSubmit}
+                  enableFeedback={enableFeedback}
+                  feedback={feedback}
+                  onFeedbackChange={handleFeedbackChange}
+                  onFeedbackSubmit={handleFeedbackSubmit}
+                  customCallConfig={customCallConfig}
+                  selectedCustomCall={selectedCustomCall}
+                  onCustomCallClick={handleCustomCallClick}
+                  fontSizes={{
+                    messageText: fontSizes.messageText,
+                    codeBlock: fontSizes.codeBlock,
+                    inlineCode: fontSizes.inlineCode,
+                    suggestionChip: fontSizes.suggestionChip,
+                    inputField: fontSizes.inputField,
+                    timestamp: fontSizes.timestamp,
+                  }}
+                />
+              );
+            })()
+          ) : (
+            <Box
+              display="flex"
+              justifyContent="center"
+              alignItems="center"
+              minHeight="200px"
+            >
+              <Typography color="textSecondary">
+                Loading chat session...
+              </Typography>
+            </Box>
+          )}
+        </div>
       </Grid>
     </Grid>
   );
@@ -3915,12 +3908,12 @@ export function AgentForgePage() {
             </Tooltip>
             {caipeVersion && (
               <Tooltip
-                title={`CAIPE Platform Version: ${caipeVersion}`}
+                title={`Agent Version: ${caipeVersion}`}
                 placement="bottom"
               >
                 <Box className={classes.customHeaderStatus}>
                   <Typography className={classes.customHeaderLabel}>
-                    CAIPE Version
+                    Agent Version
                   </Typography>
                   <Typography className={classes.customHeaderValue}>
                     v{caipeVersion}
@@ -4044,12 +4037,12 @@ export function AgentForgePage() {
           </Tooltip>
           {caipeVersion && (
             <Tooltip
-              title={`CAIPE Platform Version: ${caipeVersion}`}
+              title={`Agent Version: ${caipeVersion}`}
               placement="bottom"
             >
               <Box className={classes.customHeaderStatus}>
                 <Typography className={classes.customHeaderLabel}>
-                  CAIPE Version
+                  Agent Version
                 </Typography>
                 <Typography className={classes.customHeaderValue}>
                   v{caipeVersion}

--- a/workspaces/agent-forge/plugins/agent-forge/src/components/ChatSessionSidebar.tsx
+++ b/workspaces/agent-forge/plugins/agent-forge/src/components/ChatSessionSidebar.tsx
@@ -84,8 +84,8 @@ const useStyles = makeStyles(theme => ({
   },
   sessionItem: {
     cursor: 'pointer',
-    borderRadius: theme.shape.borderRadius,
-    margin: theme.spacing(0.5),
+    // borderRadius: theme.shape.borderRadius,
+    // margin: theme.spacing(0.5),
     maxWidth: '100%',
     overflow: 'hidden',
     '&:hover': {
@@ -101,11 +101,22 @@ const useStyles = makeStyles(theme => ({
     '&:hover': {
       backgroundColor: theme.palette.type === 'dark' ? '#00ccff' : '#01579b',
     },
+
+    '& $deleteButton': {
+      color: 'white',
+    },
+
+    '& $sessionDate': {
+      color: '#dbdbdb',
+    },
   },
   sessionText: {
     paddingRight: theme.spacing(1),
     wordBreak: 'break-word',
     overflowWrap: 'break-word',
+  },
+  sessionDate: {
+    fontSize: '0.75rem',
   },
   deleteButton: {
     padding: theme.spacing(0.5),
@@ -237,7 +248,11 @@ export function ChatSessionSidebar({
           </Tooltip>
           <Box style={{ flex: 1, overflow: 'auto', width: '100%' }}>
             {sessions.map((session, index) => (
-              <Tooltip key={session.contextId} title={session.title} placement="right">
+              <Tooltip
+                key={session.contextId}
+                title={session.title}
+                placement="right"
+              >
                 <Box
                   className={`${classes.collapsedSessionDot} ${
                     session.contextId === currentSessionId
@@ -298,7 +313,9 @@ export function ChatSessionSidebar({
             <ListItem
               key={session.contextId}
               className={`${classes.sessionItem} ${
-                session.contextId === currentSessionId ? classes.activeSession : ''
+                session.contextId === currentSessionId
+                  ? classes.activeSession
+                  : ''
               }`}
               onClick={() => onSessionSwitch(session.contextId)}
             >
@@ -309,11 +326,10 @@ export function ChatSessionSidebar({
                 primaryTypographyProps={{
                   variant: 'body2',
                   noWrap: false,
-                  style: { fontSize: sidebarTextFontSize || '0.875rem' },
                 }}
                 secondaryTypographyProps={{
                   variant: 'caption',
-                  style: { fontSize: sidebarTextFontSize || '0.875rem' },
+                  classes: { root: classes.sessionDate },
                 }}
               />
               <Tooltip title="Delete this chat session">


### PR DESCRIPTION
Makes a few different styling fixes and tweaks.

## Remove chat area padding

There was an extra border around the chat history section caused by the user of a wrapper card. I removed the card and it cleans up the layout.

Before:

<img width="286" height="198" alt="Screenshot 2025-11-20 at 12 24 37 PM" src="https://github.com/user-attachments/assets/d43854d8-1d4a-4653-b362-991ed258fbf2" />

After:

<img width="267" height="212" alt="Screenshot 2025-11-20 at 11 41 44 AM" src="https://github.com/user-attachments/assets/c367681f-35fc-40c7-97ec-435fa10876f3" />

## Chat session list tweaks

There was rendering behavior which caused one size of the active session list highlight to show rounded corners and the other size was flush, which made it look lop-sized. I removed the padding and the rounded corners so it looks a bit more natural.

I also made the delete icon for the active chat session explicitly white, and changed the color of the chat date, to improve the contrast.

Before

<img width="296" height="163" alt="Screenshot 2025-11-20 at 12 24 46 PM" src="https://github.com/user-attachments/assets/0770c037-9830-4194-bda9-86e48d2e3032" />

After (not sure why its a different shade of blue, I didn't change that)

<img width="223" height="138" alt="Screenshot 2025-11-20 at 11 42 11 AM" src="https://github.com/user-attachments/assets/065a3616-e9ed-4d1d-a570-e9e3c0e7d274" />

## CAIPE version naming

In the top right theres a section that displays the "CAIPE version". Since this plugin is designed to work with A2A this should just read "Agent Version". I can make this text configurable if needed but I'm not sure how important it is.

<img width="150" height="70" alt="Screenshot 2025-11-20 at 11 42 15 AM" src="https://github.com/user-attachments/assets/9c648450-118d-4336-ae57-acc5ba76ac35" />
